### PR TITLE
Session image select UI updates

### DIFF
--- a/donkey/remotes.py
+++ b/donkey/remotes.py
@@ -150,7 +150,7 @@ class DonkeyPilotApplication(tornado.web.Application):
 
         settings = {'debug': True}
 
-        super().__init__(handlers, debug=True)
+        super().__init__(handlers, **settings)
 
     def start(self, port=8887):
         ''' Start the tornado webserver. '''

--- a/donkey/remotes.py
+++ b/donkey/remotes.py
@@ -1,6 +1,6 @@
 """
 Classes needed to run a webserver so that the donkey can
-be controlled remotely by the user or an auto pilot. 
+be controlled remotely by the user or an auto pilot.
 """
 
 import time
@@ -24,20 +24,20 @@ import donkey as dk
 
 class RemoteClient():
     '''
-    Class used by a vehicle to send driving data and 
+    Class used by a vehicle to send driving data and
     recieve predictions from a remote webserver.
     '''
-    
+
     def __init__(self, remote_url, vehicle_id='mycar'):
 
         self.control_url = remote_url + '/api/vehicles/control/' + vehicle_id + '/'
         self.last_milliseconds = 0
-        
-        
+
+
     def decide(self, img_arr, angle, throttle, milliseconds):
         '''
         Posts current car sensor data to webserver and returns
-        angle and throttle recommendations. 
+        angle and throttle recommendations.
         '''
 
         #load features
@@ -52,25 +52,25 @@ class RemoteClient():
 
         while r == None:
             #Try connecting to server until connection is made.
-            
+
             try:
                 start = time.time()
-                r = requests.post(self.control_url, 
-                                files={'img': dk.utils.arr_to_binary(img_arr), 
-                                       'json': json.dumps(data)}) #hack to put json in file 
+                r = requests.post(self.control_url,
+                                files={'img': dk.utils.arr_to_binary(img_arr),
+                                       'json': json.dumps(data)}) #hack to put json in file
                 end = time.time()
                 lag = end-start
             except (requests.ConnectionError) as err:
-                print("Vehicle could not connect to server. Make sure you've " + 
+                print("Vehicle could not connect to server. Make sure you've " +
                     "started your server and you're referencing the right port.")
                 time.sleep(3)
 
 
-        
+
         data = json.loads(r.text)
         angle = int(float(data['angle']))
         throttle = int(float(data['throttle']))
-        
+
         print('vehicle <> server: request lag: %s' %lag)
 
         return angle, throttle
@@ -81,8 +81,8 @@ class RemoteClient():
 class DonkeyPilotApplication(tornado.web.Application):
 
     def __init__(self, data_path='~/donkey_data/'):
-        ''' 
-        Create and publish variables needed on many of 
+        '''
+        Create and publish variables needed on many of
         the web handlers.
         '''
 
@@ -109,31 +109,31 @@ class DonkeyPilotApplication(tornado.web.Application):
 
             (r"/vehicles/", VehicleListView),
 
-            (r"/vehicles/?(?P<vehicle_id>[A-Za-z0-9-]+)?/", 
+            (r"/vehicles/?(?P<vehicle_id>[A-Za-z0-9-]+)?/",
                 VehicleView),
 
 
-            (r"/api/vehicles/?(?P<vehicle_id>[A-Za-z0-9-]+)?/", 
+            (r"/api/vehicles/?(?P<vehicle_id>[A-Za-z0-9-]+)?/",
                 VehicleAPI),
 
 
-            (r"/api/vehicles/drive/?(?P<vehicle_id>[A-Za-z0-9-]+)?/", 
+            (r"/api/vehicles/drive/?(?P<vehicle_id>[A-Za-z0-9-]+)?/",
                 DriveAPI),
 
             (r"/api/vehicles/video/?(?P<vehicle_id>[A-Za-z0-9-]+)?",
                 VideoAPI
             ),
 
-            (r"/api/vehicles/control/?(?P<vehicle_id>[A-Za-z0-9-]+)?/", 
+            (r"/api/vehicles/control/?(?P<vehicle_id>[A-Za-z0-9-]+)?/",
                 ControlAPI),
 
 
             (r"/sessions/", SessionListView),
 
-            (r"/sessions/?(?P<session_id>[^/]+)?/?(?P<page>[^/]+)?", 
+            (r"/sessions/?(?P<session_id>[^/]+)?/?(?P<page>[^/]+)?",
                 SessionView),
 
-            (r"/session_image/?(?P<session_id>[^/]+)?/?(?P<img_name>[^/]+)?", 
+            (r"/session_image/?(?P<session_id>[^/]+)?/?(?P<img_name>[^/]+)?",
                 SessionImageView
             ),
 
@@ -148,7 +148,7 @@ class DonkeyPilotApplication(tornado.web.Application):
 
         settings = {'debug': True}
 
-        super().__init__(handlers, **settings)
+        super().__init__(handlers, debug=True)
 
     def start(self, port=8887):
         ''' Start the tornado webserver. '''
@@ -165,10 +165,10 @@ class DonkeyPilotApplication(tornado.web.Application):
             print('new vehicle')
             sh = dk.sessions.SessionHandler(self.sessions_path)
             self.vehicles[vehicle_id] = dict({
-                        'id': vehicle_id, 
-                        'user_angle': 0, 
-                        'user_throttle': 0,  
-                        'drive_mode':'user', 
+                        'id': vehicle_id,
+                        'user_angle': 0,
+                        'user_throttle': 0,
+                        'drive_mode':'user',
                         'milliseconds': 0,
                         'recording': False,
                         'pilot': dk.pilots.BasePilot(),
@@ -194,7 +194,7 @@ class VehicleListView(tornado.web.RequestHandler):
     def get(self):
         '''
         Serves a list of the vehicles posting requests to the server.
-        ''' 
+        '''
         data = {'vehicles':self.application.vehicles}
 
         self.render("templates/vehicle_list.html", **data)
@@ -204,7 +204,7 @@ class VehicleView(tornado.web.RequestHandler):
     def get(self, vehicle_id):
         '''
         Serves page for users to control the vehicle.
-        ''' 
+        '''
 
 
         V = self.application.get_vehicle(vehicle_id)
@@ -218,7 +218,7 @@ class VehicleAPI(tornado.web.RequestHandler):
 
     def post(self, vehicle_id):
         '''
-        Currently this only changes the pilot. 
+        Currently this only changes the pilot.
         '''
 
         V = self.application.get_vehicle(vehicle_id)
@@ -247,7 +247,7 @@ class DriveAPI(tornado.web.RequestHandler):
         angle = data['angle']
         throttle = data['throttle']
 
-        
+
 
         #set if vehicle is recording
         V['recording'] = data['recording']
@@ -264,7 +264,7 @@ class DriveAPI(tornado.web.RequestHandler):
         if throttle is not "":
             V['user_throttle'] = int(throttle)
         else:
-            V['user_throttle'] = 0    
+            V['user_throttle'] = 0
 
         print('Drive: %s: A: %s   T:%s' %(V['drive_mode'], angle, throttle))
 
@@ -272,11 +272,11 @@ class ControlAPI(tornado.web.RequestHandler):
 
     def post(self, vehicle_id):
         '''
-        Receive post requests from a vehicle and returns 
-        the angle and throttle the car should use. Depending on 
+        Receive post requests from a vehicle and returns
+        the angle and throttle the car should use. Depending on
         the drive mode the values can come from the user or
         an autopilot.
-        '''    
+        '''
 
         V = self.application.get_vehicle(vehicle_id)
 
@@ -295,9 +295,9 @@ class ControlAPI(tornado.web.RequestHandler):
 
         if V['recording'] == True:
             #save image with encoded angle/throttle values
-            V['session'].put(img, 
+            V['session'].put(img,
                              angle=V['user_angle'],
-                             throttle=V['user_throttle'], 
+                             throttle=V['user_throttle'],
                              milliseconds=V['milliseconds'])
 
         #depending on the drive mode, return user or pilot values
@@ -309,7 +309,7 @@ class ControlAPI(tornado.web.RequestHandler):
             angle, throttle  = V['pilot_angle'], V['pilot_throttle']
 
         print('Control: %s: A: %s   T:%s' %(V['drive_mode'], angle, throttle))
-        
+
 
         #retun angel/throttle values to vehicle with json response
         self.write(json.dumps({'angle': str(angle), 'throttle': str(throttle)}))
@@ -318,7 +318,7 @@ class ControlAPI(tornado.web.RequestHandler):
 
 class VideoAPI(tornado.web.RequestHandler):
     '''
-    Serves a MJPEG of the images posted from the vehicle. 
+    Serves a MJPEG of the images posted from the vehicle.
     '''
     @tornado.web.asynchronous
     @tornado.gen.coroutine
@@ -330,7 +330,7 @@ class VideoAPI(tornado.web.RequestHandler):
         self.served_image_timestamp = time.time()
         my_boundary = "--boundarydonotcross"
         while True:
-            
+
             interval = .2
             if self.served_image_timestamp + interval < time.time():
 
@@ -340,7 +340,7 @@ class VideoAPI(tornado.web.RequestHandler):
 
                 self.write(my_boundary)
                 self.write("Content-type: image/jpeg\r\n")
-                self.write("Content-length: %s\r\n\r\n" % len(img)) 
+                self.write("Content-length: %s\r\n\r\n" % len(img))
                 self.write(img)
                 self.served_image_timestamp = time.time()
                 yield tornado.gen.Task(self.flush)
@@ -388,19 +388,19 @@ class SessionImageView(tornado.web.RequestHandler):
         s = o.getvalue()
 
         self.set_header('Content-type', 'image/jpg')
-        self.set_header('Content-length', len(s))   
-        
-        self.write(s)   
+        self.set_header('Content-length', len(s))
+
+        self.write(s)
 
 
 
 class SessionListView(tornado.web.RequestHandler):
 
     def get(self):
-        '''  
-        Serves a page showing a list of all the session folders.  
-        TODO: Move this list creation to the session handler. 
-        '''    
+        '''
+        Serves a page showing a list of all the session folders.
+        TODO: Move this list creation to the session handler.
+        '''
 
         session_dirs = [f for f in os.scandir(self.application.sessions_path) if f.is_dir() ]
         data = {'session_dirs': session_dirs}
@@ -412,9 +412,9 @@ class SessionView(tornado.web.RequestHandler):
 
     def get(self, session_id, page):
         '''
-        Shows all the images saved in the session. 
+        Shows all the images saved in the session.
         TODO: Add pagination.
-        '''    
+        '''
         from operator import itemgetter
 
         sessions_path = self.application.sessions_path
@@ -424,7 +424,7 @@ class SessionView(tornado.web.RequestHandler):
 
         perpage = 100
         pages = math.ceil(img_count/perpage)
-        if page is None: 
+        if page is None:
             page = 1
         else:
             page = int(page)
@@ -433,18 +433,18 @@ class SessionView(tornado.web.RequestHandler):
         end = min(end, img_count)
 
 
-        sorted_imgs = sorted(imgs, key=itemgetter('name')) 
+        sorted_imgs = sorted(imgs, key=itemgetter('name'))
         page_list = [p+1 for p in range(pages)]
         session = {'name':session_id, 'imgs': sorted_imgs[start:end]}
-        data = {'session': session, 'page_list': page_list}
+        data = {'session': session, 'page_list': page_list, 'page': page}
         self.render("templates/session.html", **data)
 
     def post(self, session_id, page):
-        ''' 
-        Deletes selected images 
+        '''
+        Deletes selected images
         TODO: move this to an api cal. Page is not needed.
         '''
-        
+
         data = tornado.escape.json_decode(self.request.body)
 
         if data['action'] == 'delete_images':
@@ -454,10 +454,3 @@ class SessionView(tornado.web.RequestHandler):
             for i in data['imgs']:
                 os.remove(os.path.join(path, i))
                 print('%s removed' %i)
-
-
-
-
-
-
-

--- a/donkey/templates/base.html
+++ b/donkey/templates/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Donkey Monitor </title>
-  
+
 
 
   <script
@@ -46,7 +46,7 @@
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">
         <li><a href="/vehicles/">Vehicles</a></li>
-        <li class="active"><a href="/pilots/">Pilots <span class="sr-only">(current)</span></a></li>
+        <li><a href="/pilots/">Pilots <span class="sr-only">(current)</span></a></li>
         <li><a href="/sessions/">Sessions</a></li>
       </ul>
     </div><!-- /.navbar-collapse -->

--- a/donkey/templates/session.html
+++ b/donkey/templates/session.html
@@ -4,74 +4,111 @@
 
 	<body>
 
-
-
-
-	  <style>
-	  #selectable .ui-selecting { background: #FECA40; }
-	  #selectable .ui-selected { background: #F39814; color: white; }
-	  </style>
-
-		<h2> Sessions {{ escape(session['name'])}} </h2>
-
 		<div>
-		{% for p in page_list %}
-			<span> <a href="./{{p}}"> {{p}} </a> </span> 
-		{% end %}
+
 		</div>
 
-		<div class="dropdown">
-		  <button id="dLabel" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-		    Actions
-		    <span class="caret"></span>
-		  </button>
-		  <ul class="dropdown-menu" id="deleteButton" aria-labelledby="dLabel">
-		    <li><a href="#">Delete Selected</a></li>
-		  </ul>
-		</div>
-
-
-		<div id="selectable">
-		{% for img in session['imgs'] %}
-			<div class="img ui-state-default" id="{{ img['name'] }}">
-				<img src="/session_image/{{session['name']}}/{{ img['name'] }}" > 
-
-				<span class="desc">Angle: {{img['angle']}}</span>
-				<span class="desc">Throttle: {{img['throttle']}}</span>
+		<div class="container-fluid">
+			<div class="row">
+				<div class="col-md-12">
+					<h2>{{ escape(session['name'])}} </h2>
+					<ol class="breadcrumb">
+					  <li><a href="/sessions/">sessions</a></li>
+					  <li><a href="/sessions/{{ escape(session['name'])}}/">{{ escape(session['name'])}}</a></li>
+					</ol>
+				</div>
 			</div>
 
-		{% end %}
+			<div class="row">
+				<div class="col-md-12">
+					<nav aria-label="Page navigation">
+					  <ul class="pagination">
+					    <li>
+					      <a href="./{{page - 1}}" aria-label="Previous">
+					        <span aria-hidden="true">&laquo;</span>
+					      </a>
+					    </li>
+
+							{% for p in page_list %}
+								<li ><a href="./{{p}}"> {{p}} </a></li>
+							{% end %}
+
+					    <li>
+					      <a href="./{{page + 1}}" aria-label="Next">
+					        <span aria-hidden="true">&raquo;</span>
+					      </a>
+					    </li>
+					  </ul>
+					</nav>
+				</div>
+			</div>
+
+			<div class="row">
+				<div class="col-md-10">
+					<div class="checkbox">
+						<label>
+							<input type="checkbox" value="" id="select-all">
+							Select All Images on Current Page
+						</label>
+					</div>
+				</div>
+				<div class="col-md-2">
+					<input class="btn btn-danger" type="button" value="Delete Selected" id="delete-all">
+				</div>
+			</div>
+
+			<div class="row">
+				<div class="col-md-12 session-thumbnails">
+					{% for img in session['imgs'] %}
+					<div class="checkbox" id="{{ img['name'] }}">
+						<label>
+							<input type="checkbox" class="img-check" value="{{ img['name'] }}">
+							<div class="thumbnail">
+								<img src="/session_image/{{session['name']}}/{{ img['name'] }}" class="img-responsive">
+								<div class="caption">
+									<p class="small desc">Angle: {{img['angle']}}</p>
+									<p class="small desc">Throttle: {{img['throttle']}}</p>
+								</div>
+							</div>
+						</label>
+					</div>
+
+					{% end %}
+				</div>
+			</div>
 		</div>
+
 		<script>
-		$( function() {
-			var selected = new Array();
-			$("#selectable").selectable({
-			    stop: function( event, ui ) {      
-			    	selected = []
-			    	$('.img.ui-selected').each(function() {
-					    selected.push(this.id);
-					});     
-					console.log(selected)
-			    }
+		$(document).ready(function() {
+
+			$('#select-all').click(function(event) {
+				$(".img-check").prop('checked', $(this).prop("checked"));
 			});
 
-			var deleteImages = function () {
-				
-			}
+	    $('#delete-all').click(function(){
+			  var selected = []
 
+				// Build array of selected images
+				$(".img-check:checked").each(function() {
+					selected.push($(this).val());
+				});
 
-		    $('#deleteButton').click(function(){
-						           //Send post request to server.
-				    data = JSON.stringify({ 'imgs': selected, 
-				                            'session_id': $('#session_id').data('id'),
-				                            'action':'delete_images'});
-				    console.log(data)
+				//Send post request to server.
+		    data = JSON.stringify({ 'imgs': selected,
+		                            'session_id': $('#session_id').data('id'),
+		                            'action':'delete_images'});
 
-				  $.post('', data)
-		    });
+		    console.log(data);
+		  	$.post('', data);
+
+				$(selected).each(function( index, value ) {
+					console.log(value);
+					$("[id='" + value + "']").remove();
+				});
+	    });
 		} );
 		</script>
-	
+
 	<div class='meta' style="display:none">
 		<span id="session_id" data-id={{ escape(session['name'])}}>session_id:  {{ escape(session['name'])}} </span>
 	</div>

--- a/donkey/templates/session.html
+++ b/donkey/templates/session.html
@@ -11,11 +11,7 @@
 		<div class="container-fluid">
 			<div class="row">
 				<div class="col-md-12">
-					<h2>{{ escape(session['name'])}} </h2>
-					<ol class="breadcrumb">
-					  <li><a href="/sessions/">sessions</a></li>
-					  <li><a href="/sessions/{{ escape(session['name'])}}/">{{ escape(session['name'])}}</a></li>
-					</ol>
+					<h2><span class="text-muted">Session:</span> {{ escape(session['name'])}} </h2>
 				</div>
 			</div>
 
@@ -74,6 +70,28 @@
 					</div>
 
 					{% end %}
+					<div class="row">
+						<div class="col-md-12">
+							<nav aria-label="Page navigation">
+								<ul class="pagination">
+									<li>
+										<a href="./{{page - 1}}" aria-label="Previous">
+											<span aria-hidden="true">&laquo;</span>
+										</a>
+									</li>
+
+									{% for p in page_list %}
+										<li ><a href="./{{p}}"> {{p}} </a></li>
+									{% end %}
+
+									<li>
+										<a href="./{{page + 1}}" aria-label="Next">
+											<span aria-hidden="true">&raquo;</span>
+										</a>
+									</li>
+								</ul>
+							</nav>
+						</div>
 				</div>
 			</div>
 		</div>

--- a/donkey/templates/session_list.html
+++ b/donkey/templates/session_list.html
@@ -2,7 +2,7 @@
 {% extends "base.html" %}
 {% block content %}
 	<div class="container">
-		<h2> Sessions </h2>
+		<h2>Sessions </h2>
 
 		    <ul>
 		      {% for dir in session_dirs %}
@@ -18,6 +18,6 @@
 				</div>
 		      {% end %}
 		    </ul>
-		    
+
 	</div>
 {% end %}

--- a/donkey/templates/static/style.css
+++ b/donkey/templates/static/style.css
@@ -1,10 +1,10 @@
 
-#joystick_container { 
-	position: fixed; 
-	bottom:0; 
-	right:0; 
-	width: 400px; 
-	height:40%; 
+#joystick_container {
+	position: fixed;
+	bottom:0;
+	right:0;
+	width: 400px;
+	height:40%;
 	border:1pt solid black;
 	background-color: rgba(255, 0, 0, 0.1);
 }
@@ -19,8 +19,8 @@
 		width: 100%;
 	}
 
-	#joystick_container { 
-		width:100%; 
+	#joystick_container {
+		width:100%;
 	}
 }
 
@@ -44,4 +44,26 @@ div.img img {
 div.desc {
     padding: 15px;
     text-align: center;
+}
+
+div.session-thumbnails img {
+	width: 160px;
+	height: auto;
+}
+
+div.session-thumbnails .desc {
+	margin-bottom:0px;
+}
+
+div.session-thumbnails .checkbox {
+	display:inline;
+}
+
+div.session-thumbnails label {
+	padding-left: 0px;
+}
+
+div.session-thumbnails input[type=checkbox] {
+	margin-top: 10px;
+	margin-left: 10px;
 }

--- a/donkey/templates/static/style.css
+++ b/donkey/templates/static/style.css
@@ -59,6 +59,10 @@ div.session-thumbnails .checkbox {
 	display:inline;
 }
 
+div.session-thumbnails .caption {
+	padding:5px 5px 0px 5px;
+}
+
 div.session-thumbnails label {
 	padding-left: 0px;
 }


### PR DESCRIPTION
This PR adds:
- a more performant method of selecting multiple images on the session page
- select all capability for images on the session page
- removes a selector that always marked the `Pilots` navigation tab as active.

@wroscoe Looks like my editor has a different whitespace setting than yours. Let me know if you'd like me to redo this without the whitespace changes.