### PR TITLE
Draggable multiselect and turn icons

### DIFF
--- a/donkey/remotes.py
+++ b/donkey/remotes.py
@@ -444,7 +444,7 @@ class SessionView(tornado.web.RequestHandler):
         imgs = [dk.utils.merge_two_dicts({'name':f.name}, dk.sessions.parse_img_filepath(f.path)) for f in os.scandir(path) if f.is_file() ]
         img_count = len(imgs)
 
-        perpage = 1000
+        perpage = 500
         pages = math.ceil(img_count/perpage)
         if page is None: 
             page = 1

--- a/donkey/templates/session.html
+++ b/donkey/templates/session.html
@@ -13,20 +13,18 @@
 			
 			<div class="row">
 				<div class="col-md-12 session-thumbnails">
-					{% for img in session['imgs'] %}					
-						<div class="checkbox" id="{{ img['name'] }}">
-							<label>
-								<input type="checkbox" class="img-check" value="{{ img['name'] }}">
-								<div class="thumbnail">
-									<img src="/session_image/{{session['name']}}/{{ img['name'] }}" class="img-responsive">
-									<div class="caption">
-										<p class="small desc">Angle: {{img['angle']}}</p>
-										<p class="small desc">Throttle: {{img['throttle']}}</p>
-									</div>
+					<ol id="selectable">
+						<p class="text-muted"><em>Click and drag to select images, command + click to select multiple single images.</em></p>
+						{% for img in session['imgs'] %}					
+							<li class="thumbnail" id="{{ img['name'] }}">
+								<img src="/session_image/{{session['name']}}/{{ img['name'] }}" class="img-responsive">
+								<div class="caption">
+									<p class="small desc">Angle: {{img['angle']}}</p>
+									<p class="small desc">Throttle: {{img['throttle']}}</p>
 								</div>
-							</label>
-						</div>
-					{% end %}
+							</li>
+						{% end %}
+					</ol>
 				</div>
 			</div>
 		</div>
@@ -58,12 +56,12 @@
 			
 			<div class="col-md-3 img-controls text-right">
 				<div class="form-inline">
-					<div class="checkbox">
-						<label>
-							<input type="checkbox" value="" id="select-all">
-							Select All
-						</label>
-					</div>
+					<label>
+						<span id="select-result">0</span> selected
+					</label>
+					<label class="btn btn-default">
+						<input id="select-all" type="checkbox"> Select All
+					</label>
 					<input class="btn btn-danger" type="button" value="Delete Selected" id="delete-all">
 				</div>
 			</div>
@@ -77,18 +75,39 @@
 
 	<script>
 		$(document).ready(function() {
-
-			$('#select-all').click(function(event) {
-				$(".img-check").prop('checked', $(this).prop("checked"));
+			
+			$( "#selectable" ).selectable({
+			  filter: 'li',
+				autoRefresh: false,
+				
+				stop: function() {
+					$( "#select-result" ).text(function( index ) {
+					  return $('.ui-selected').length;
+					});
+      	}
 			});
+			
+			$('#select-all').on('click', function () {
+				if ($(this).is(":checked")) {
+					$('.thumbnail').addClass('ui-selected');
+				} else {
+					$('.thumbnail').removeClass('ui-selected');
+				}
+				
+				$( "#select-result" ).text(function( index ) {
+					return $('.ui-selected').length;
+				});
+			})
 
 			$('#delete-all').click(function(){
 				var selected = []
 
 				// Build array of selected images
-				$(".img-check:checked").each(function() {
-					selected.push($(this).val());
+				$(".ui-selected").each(function() {
+					selected.push(this.id);
 				});
+				
+				console.log(selected);
 
 				//Send post request to server.
 				data = JSON.stringify({ 'imgs': selected,
@@ -102,6 +121,7 @@
 				$(selected).each(function( index, value ) {
 					console.log(value);
 					$("[id='" + value + "']").remove();
+					$( "#selectable" ).selectable( "refresh" );
 				});
 			});
 			

--- a/donkey/templates/session.html
+++ b/donkey/templates/session.html
@@ -19,8 +19,18 @@
 							<li class="thumbnail" id="{{ img['name'] }}">
 								<img src="/session_image/{{session['name']}}/{{ img['name'] }}" class="img-responsive">
 								<div class="caption">
-									<p class="small desc">Angle: {{img['angle']}}</p>
-									<p class="small desc">Throttle: {{img['throttle']}}</p>
+									<p class="small desc">
+										{% if img['angle'] < 0 %}
+											<span class="glyphicon glyphicon-arrow-left"></span>
+										{% elif img['angle'] ==0 %}
+											<span class="glyphicon glyphicon-arrow-up"></span>
+										{% elif img['angle'] > 0 %}
+											<span class="glyphicon glyphicon-arrow-right"></span>
+										{% end %}
+										Angle: {{img['angle']}}</p>
+									<p class="small desc">
+										<span class="glyphicon glyphicon-dashboard"></span>
+										Throttle: {{img['throttle']}}</p>
 								</div>
 							</li>
 						{% end %}

--- a/donkey/templates/session.html
+++ b/donkey/templates/session.html
@@ -42,7 +42,7 @@
 	<footer class='footer' >
 		<div class="container-fluid">
 			
-			<div class="col-md-9">
+			<div class="col-md-8">
 				<nav aria-label="Page navigation">
 					<ul class="pagination">
 						<li>
@@ -64,7 +64,7 @@
 				</nav>
 			</div>
 			
-			<div class="col-md-3 img-controls text-right">
+			<div class="col-md-4 img-controls text-right">
 				<div class="form-inline">
 					<label>
 						<span id="select-result">0</span> selected

--- a/donkey/templates/static/style.css
+++ b/donkey/templates/static/style.css
@@ -24,6 +24,16 @@
 	}
 }
 
+div.session-thumbnails .ui-selecting {
+	background-color: #fcf8e3;
+	border-color: #faebcc;
+}
+
+div.session-thumbnails .ui-selected {
+	background-color: #f2dede;
+	border-color: #ebccd1;
+}
+
 div.session-thumbnails img {
 	width: 160px;
 	height: auto;
@@ -33,8 +43,10 @@ div.session-thumbnails .desc {
 	margin-bottom:0px;
 }
 
-div.session-thumbnails .checkbox {
-	display:inline;
+div.session-thumbnails li.thumbnail {
+	width:170px;
+	float: left;
+	margin-right:5px;
 }
 
 div.session-thumbnails .caption {
@@ -45,17 +57,8 @@ div.session-thumbnails label {
 	padding-left: 0px;
 }
 
-div.session-thumbnails input[type=checkbox] {
-	margin-top: 10px;
-	margin-left: 10px;
-}
-
 div.img-controls {
 	margin: 20px 0;
-}
-
-div.img-controls .checkbox {
-	margin-right: 10px;
 }
 
 


### PR DESCRIPTION
@wroscoe I added back the click-to-drag multiselect capabilty with some filters that make it more performant. This feels pretty snappy on my computer for session pages with up to 500 images. Beyond that it lags pretty badly, so I updated the pagination code to break the pages at 500 instead of 1000.

Also adds iconography to indicate turn direction (requested by @adammconway).