### PR TITLE
Gamepad toggle

### DIFF
--- a/donkey/templates/static/main.js
+++ b/donkey/templates/static/main.js
@@ -299,10 +299,7 @@ var driveHandler = (function() {
           {
             
             var joystickX = applyDeadzone(pad.axes[2], 0.05);
-            console.log("gamepadX: " + joystickX);
-
             var joystickY = applyDeadzone(pad.axes[1], 0.15);
-            console.log("gamepadY: " + joystickY);
             
             state.tele.user.angle = joystickX;
             state.tele.user.throttle = limitedThrottle((joystickY * -1));

--- a/donkey/templates/vehicle.html
+++ b/donkey/templates/vehicle.html
@@ -11,10 +11,12 @@
         <div class="form-inline">
           <div class="form-group">
             <label class="group-label">
-              <a data-toggle="modal" data-target="#aboutControlModes">
-              Control Mode <span class="glyphicon glyphicon-info-sign"></span>
+              Control Mode
+              <a data-toggle="modal" class="btn btn-primary btn-xs" data-target="#aboutControlModes">
+                <span class="glyphicon glyphicon-info-sign"></span>
               </a>
-            </label><br/>
+            </label>
+            <br/>
             <div class="btn-group" data-toggle="buttons">
               <label class="btn btn-primary" id="joystick-toggle">
                 <input type="radio" name="controlMode" id="joystick" autocomplete="off" value="joystick"> Joystick
@@ -157,7 +159,7 @@
           
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
         </div>
       </div>
     </div>

--- a/donkey/templates/vehicle.html
+++ b/donkey/templates/vehicle.html
@@ -10,7 +10,11 @@
         </div>
         <div class="form-inline">
           <div class="form-group">
-            <label class="group-label">Control Mode</label><br/>
+            <label class="group-label">
+              <a data-toggle="modal" data-target="#aboutControlModes">
+              Control Mode <span class="glyphicon glyphicon-info-sign"></span>
+              </a>
+            </label><br/>
             <div class="btn-group" data-toggle="buttons">
               <label class="btn btn-primary" id="joystick-toggle">
                 <input type="radio" name="controlMode" id="joystick" autocomplete="off" value="joystick"> Joystick
@@ -125,6 +129,39 @@
       </div>
     </div>
   </footer>
+
+  <!-- Modal -->
+  <div class="modal fade" id="aboutControlModes" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title" id="myModalLabel">About Control Modes</h4>
+        </div>
+        <div class="modal-body">
+          <p>
+            <strong>Joystick</strong> control is provided via the blue touch/click area on screen. Click or touch and drag to control throttle and steering. In joystick mode, you can also use the following keyboard keys:
+            <ul>
+              <li>Forward: <code>I</code></li>
+              <li>Reverse: <code>K</code></li>
+              <li>Left: <code>J</code> </li>
+              <li>Right: <code>L</code></li>
+            </ul>
+          </p>
+          <p>
+            <strong>Gamepad</strong> control is enabled by the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API/Using_the_Gamepad_API">HTML5 gamepad API</a>, currently supported by Chrome and Firefox. Playstation 3 controllers have been confirmed to work.
+          </p>
+          <p>
+            <strong>Device tilt</strong> control is enabled for devices with <a href="https://developer.mozilla.org/en-US/docs/Web/API/Detecting_device_orientation">device orientation sensors</a>, and should work with most modern smartphones. Hold your device in landscape mode, tilt  forward/backward for throttle and left/right for steering.
+          </p> 
+          
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
 <script type="text/javascript">
   $( document ).ready(function() {

--- a/donkey/templates/vehicle.html
+++ b/donkey/templates/vehicle.html
@@ -15,6 +15,9 @@
               <label class="btn btn-primary" id="joystick-toggle">
                 <input type="radio" name="controlMode" id="joystick" autocomplete="off" value="joystick"> Joystick
               </label>
+              <label class="btn btn-primary" id="gamepad-toggle">
+                <input type="radio" name="controlMode" id="gamepad" autocomplete="off" value="gamepad"> Gamepad
+              </label>
               <label class="btn btn-primary" id="tilt-toggle">
                 <input type="radio" name="controlMode" id="tilt" autocomplete="off" value="tilt">Device Tilt
               </label>


### PR DESCRIPTION
- Add control mode toggle for gamepad (disabled when no gamepad present)
- Gamepad throttle respects max throttle setting
- Disable joystick loop when in gamepad mode to prevent conflicting control inputs (and vice-versa)
- Add modal explaining control modes (accessed by clicking on the Control Modes form label)