### PR TITLE
Add constant throttle option

### DIFF
--- a/config/vehicle.ini
+++ b/config/vehicle.ini
@@ -13,9 +13,8 @@ min_pulse=220
 
 [steering_actuator]
 channel=1
-left_pulse=220
-right_pulse=370
-
+left_pulse=523
+right_pulse=225
 
 [pilot]
 model_path=~/mydonkey/models/default.h5

--- a/donkey/templates/static/main.js
+++ b/donkey/templates/static/main.js
@@ -21,6 +21,7 @@ var driveHandler = (function() {
                   'lag': 0,
                   'controlMode': 'joystick',
                   'maxThrottle' : 1,
+                  'throttleMode' : 'user',
                   }
 
     var joystick_options = {}
@@ -95,7 +96,11 @@ var driveHandler = (function() {
       });
       
       $('#max_throttle_select').on('change', function () {
-        state.maxThrottle = $(this).val();
+        state.maxThrottle = parseFloat($(this).val());
+      });
+      
+      $('#throttle_mode_select').on('change', function () {
+        state.throttleMode = $(this).val();
       });
       
       $('#record_button').click(function () {
@@ -459,6 +464,10 @@ var driveHandler = (function() {
       
       if (newThrottle < 0) {
         limitedThrottle = Math.max((state.maxThrottle * -1), newThrottle);
+      }
+      
+      if (state.throttleMode == 'constant') {
+        limitedThrottle = state.maxThrottle;
       }
       
       return limitedThrottle;

--- a/donkey/templates/vehicle.html
+++ b/donkey/templates/vehicle.html
@@ -34,9 +34,18 @@
             <div class="form-group">
               <select id="max_throttle_select" class="form-control">
                 <option disabled selected> Select Max Throttle </option>
-                {% for t in [10, 20, 40, 60, 80, 100] %}
+                {% for t in [5, 10, 15, 20, 25, 30, 35, 40, 60, 80, 100] %}
                   <option value="{{ t / 100.0 }}">{{ t }}%</option>
                 {% end %}
+              </select>
+            </div>
+          </div>
+          <div class="form-group" style="max-width:30%;">
+            <label class="group-label">Throttle Mode</label><br/>
+            <div class="form-group">
+              <select id="throttle_mode_select" class="form-control">
+                <option value="user" selected>User</option>
+                <option value="constant">Constant (Selected Max)</option>
               </select>
             </div>
           </div>

--- a/scripts/simulate.py
+++ b/scripts/simulate.py
@@ -16,6 +16,7 @@ import os
 
 import donkey as dk
 from docopt import docopt
+from os.path import expanduser
 
 args = docopt(__doc__)  
 
@@ -30,8 +31,9 @@ if args['--remote'] is not None:
 else:
     remote_url = 'http://localhost:8887'
 
+model_path = expanduser("~") + '/mydonkey/models/default.h5'
 remote = dk.remotes.RemoteClient(remote_url, vehicle_id='mysim')
-pilot = dk.pilots.KerasCategorical(model_path='/home/wroscoe/mydonkey/models/ms.h5')
+pilot = dk.pilots.KerasCategorical(model_path=model_path)
 pilot.load()
 
 car = dk.vehicles.BaseVehicle(drive_loop_delay=.05,


### PR DESCRIPTION
- To use constant throttle, you must select a max throttle value (constant throttle will use this max value as the throttle)
- Also fixes a variable type problem for the max throttle setting (now properly converts to the string value from the form to the float value expected by the server)
- Also replaces the user-specific model path in `simulate.py` with a more general path to the default model
- Corrects the steering PWM settings in the default vehicle.ini to match the Magnet.