### PR TITLE
Add more button controls for PS3 controller

### DIFF
--- a/donkeycar/parts/controllers/joystick.py
+++ b/donkeycar/parts/controllers/joystick.py
@@ -211,6 +211,7 @@ class JoystickPilot():
         self.steering_scale = steering_scale
         self.throttle_scale = throttle_scale
         self.recording = False
+        self.constant_throttle = False
 
         #init joystick
         self.js = Joystick(dev_fn)
@@ -225,7 +226,25 @@ class JoystickPilot():
     def update(self):
         '''
         poll a joystick for input events
+
+        button map name => PS3 button => function
+        * top2 = PS3 dpad up => increase throttle scale
+        * base = PS3 dpad down => decrease throttle scale
+        * base2 = PS3 dpad left => increase steering scale 
+        * pinkie = PS3 dpad right => decrease steering scale
+        * trigger = PS3 select => switch modes
+        * top = PS3 start => toggle constant throttle
+        * base5 = PS3 left trigger 1 
+        * base3 = PS3 left trigger 2
+        * base6 = PS3 right trigger 1 
+        * base4 = PS3 right trigger 2
+        * thumb2 = PS3 right thumb
+        * thumb = PS3 left thumb
+        * circle = PS3 circrle => toggle recording
+        * triangle = PS3 triangle => increase max throttle
+        * cross = PS3 cross => decrease max throttle
         '''
+
         while self.running:
             button, button_state, axis, axis_val = self.js.poll()
         
@@ -253,7 +272,92 @@ class JoystickPilot():
                     self.mode = 'user'
                 print('new mode:', self.mode)
 
-            self.recording = (self.throttle != 0.0 and self.mode == 'user')                
+            
+            if button == 'trigger' and button_state == 1:
+                '''
+                switch modes from:
+                user: human controlled steer and throttle
+                local_angle: ai steering, human throttle
+                local: ai steering, ai throttle
+                '''
+                if self.mode == 'user':
+                    self.mode = 'local_angle'
+                elif self.mode == 'local_angle':
+                    self.mode = 'local'
+                else:
+                    self.mode = 'user'
+                print('new mode:', self.mode)
+
+            if button == 'circle' and button_state == 1:
+                '''
+                toggle recording on/off
+                '''
+                if self.recording:
+                    self.recording = False
+                else:
+                    self.recording = True
+
+                print('recording:', self.recording)
+
+            if button == 'triangle' and button_state == 1:
+                '''
+                increase max throttle setting
+                '''
+                self.max_throttle = round(min(1.0, self.max_throttle + 0.05), 2)
+                if self.constant_throttle:
+                    self.throttle = self.max_throttle
+
+                print('max_throttle:', self.max_throttle)
+
+            if button == 'cross' and button_state == 1:
+                '''
+                decrease max throttle setting
+                '''
+                self.max_throttle = round(max(0.0, self.max_throttle - 0.05), 2)
+                if self.constant_throttle:
+                    self.throttle = self.max_throttle
+                    
+                print('max_throttle:', self.max_throttle)
+
+            if button == 'base' and button_state == 1:
+                '''
+                increase throttle scale
+                '''
+                self.throttle_scale = round(min(0.0, self.throttle_scale + 0.05), 2)
+                print('throttle_scale:', self.throttle_scale)
+
+            if button == 'top2' and button_state == 1:
+                '''
+                decrease throttle scale
+                '''
+                self.throttle_scale = round(max(-1.0, self.throttle_scale - 0.05), 2)
+                print('throttle_scale:', self.throttle_scale)
+
+            if button == 'base2' and button_state == 1:
+                '''
+                increase steering scale
+                '''
+                self.steering_scale = round(min(1.0, self.steering_scale + 0.05), 2)
+                print('steering_scale:', self.steering_scale)
+
+            if button == 'pinkie' and button_state == 1:
+                '''
+                decrease steering scale
+                '''
+                self.steering_scale = round(max(0.0, self.steering_scale - 0.05), 2)
+                print('steering_scale:', self.steering_scale)
+
+            if button == 'top' and button_state == 1:
+                '''
+                toggle constant throttle
+                '''
+                if self.constant_throttle:
+                    self.constant_throttle = False
+                    self.throttle = 0
+                else:
+                    self.constant_throttle = True
+                    self.throttle = self.max_throttle
+                print('constant_throttle:', self.constant_throttle)           
 
             time.sleep(self.poll_delay)
 


### PR DESCRIPTION
Recording is manually toggled in this version. Additional controls added:

        button map name => PS3 button => function
        * top2 = PS3 dpad up => increase throttle scale
        * base = PS3 dpad down => decrease throttle scale
        * base2 = PS3 dpad left => increase steering scale 
        * pinkie = PS3 dpad right => decrease steering scale
        * trigger = PS3 select => switch modes
        * top = PS3 start => toggle constant throttle
        * circle = PS3 circrle => toggle recording
        * triangle = PS3 triangle => increase max throttle
        * cross = PS3 cross => decrease max throttle