### PR TITLE
Nasty bug in multi-tub training

### DIFF
--- a/donkeycar/parts/stores/tub.py
+++ b/donkeycar/parts/stores/tub.py
@@ -188,12 +188,11 @@ class Tub(object):
     def record_gen(self, index=None, record_transform=None):
         if index==None:
             index=self.get_index(shuffled=True)
-        while True:
-            for i in index:
-                record = self.get_record(i)
-                if record_transform:
-                    record = record_transform(record)
-                yield record
+        for i in index:
+            record = self.get_record(i)
+            if record_transform:
+                record = record_transform(record)
+            yield record
 
     def batch_gen(self, keys=None, index=None, batch_size=128,
                   record_tranform=None):


### PR DESCRIPTION
This is to fix a nasty bug that prevented training from moving beyond the 1st tub. It was probably the reason why your model didn't work @wroscoe, and none of the Donkey cars did well Saturday. I feel so bad about it!

Also this fix would require everyone to regenerate manage.py.

One drawback of this implementation is that up to batch_size records in each tub may not be used at all. This is because now `get_record` will throw `StopIteration` exception when there aren't enough records to fill a whole batch so that `itertools.chain` can move on to next tub.