### PR TITLE
Fixed quotes in documentation

### DIFF
--- a/docs/guide/install_software.md
+++ b/docs/guide/install_software.md
@@ -32,8 +32,8 @@ ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 update_config=1
 
 network={
-    ssid=”<your network name>”
-    psk=”<your password>”
+    ssid="<your network name>"
+    psk="<your password>"
 }
 
 ```


### PR DESCRIPTION
If the terminal or editor supports pasting unicode, it'll look alright, but not parse and the car won't join the network.