### PR TITLE
Prevent the generators from being cached

### DIFF
--- a/donkeycar/parts/__init__.py
+++ b/donkeycar/parts/__init__.py
@@ -35,6 +35,7 @@ from .stores.tub import TubReader
 from .stores.tub import TubWriter
 from .stores.tub import TubHandler
 from .stores.tub import TubImageStacker
+from .stores.tub import TubChain
 
 from .transforms import Lambda
 

--- a/donkeycar/parts/stores/tub.py
+++ b/donkeycar/parts/stores/tub.py
@@ -11,6 +11,7 @@ import time
 import json
 import datetime
 import random
+import itertools
 
 from PIL import Image
 
@@ -402,3 +403,49 @@ class TubImageStacker(Tub):
                     val = np.array(img)
 
         return data
+
+
+class TubChain:
+    '''
+    Multiple tubs chained together to generate data in one single training session
+    '''
+
+    def __init__(self, tub_paths, X_keys, Y_keys, batch_size=32, record_transform=None, train_split=.8):
+        self.X_keys = X_keys
+        self.Y_keys = Y_keys
+        self.batch_size = batch_size
+        self.record_transform = record_transform
+
+        self.tub_dataset_splits = []
+
+        for p in tub_paths:
+            tub = Tub(p)
+            index = tub.get_index(shuffled=True)
+            train_cutoff = int(len(index)*train_split)
+            train_index = index[:train_cutoff]
+            val_index = index[train_cutoff:]
+            self.tub_dataset_splits.append((tub, train_index, val_index))
+    
+    def train_gen(self):
+        while True:
+            gens = [tub_ds[0].train_gen(X_keys=self.X_keys, Y_keys=self.Y_keys, index=tub_ds[1],
+                batch_size=self.batch_size, record_transform=self.record_transform)
+                for tub_ds in self.tub_dataset_splits]
+
+            for batch in itertools.chain(*gens):
+                yield batch
+
+    def val_gen(self):
+        while True:
+            gens = [tub_ds[0].train_gen(X_keys=self.X_keys, Y_keys=self.Y_keys, index=tub_ds[2],
+                batch_size=self.batch_size, record_transform=self.record_transform)
+                for tub_ds in self.tub_dataset_splits]
+
+            for batch in itertools.chain(*gens):
+                yield batch
+
+    def train_val_gen(self):
+        return self.train_gen(), self.val_gen()
+
+    def total_records(self):
+        return sum([t[0].get_num_records() for t in self.tub_dataset_splits])

--- a/donkeycar/templates/donkey2.py
+++ b/donkeycar/templates/donkey2.py
@@ -4,7 +4,7 @@ Scripts to drive a donkey 2 car and train a model for it.
 
 Usage:
     manage.py (drive) [--model=<model>] [--js]
-    manage.py (train) [--tub=<tub1,tub2,..tubn>] (--model=<model>)
+    manage.py (train) [--tub=<tub1,tub2,..tubn>] (--model=<model>) [--cache]
     manage.py (calibrate)
     manage.py (check) [--tub=<tub1,tub2,..tubn>] [--fix]
     manage.py (analyze) [--tub=<tub1,tub2,..tubn>] (--op=<histogram>) (--rec=<"user/angle">)
@@ -153,7 +153,7 @@ def gather_tubs(cfg, tub_names):
         return [os.path.join(cfg.DATA_PATH, n) for n in os.listdir(cfg.DATA_PATH)]
 
 
-def train(cfg, tub_names, model_name):
+def train(cfg, tub_names, model_name, cache):
     '''
     use the specified data in tub_names to train an artifical neural network
     saves the output trained model as model_name
@@ -169,7 +169,7 @@ def train(cfg, tub_names, model_name):
     
     tub_paths = gather_tubs(cfg, tub_names)
 
-    tub_chain = dk.parts.TubChain(tub_paths, X_keys, y_keys, record_transform=rt, batch_size=cfg.BATCH_SIZE, train_split=cfg.TRAIN_TEST_SPLIT)
+    tub_chain = dk.parts.TubChain(tub_paths, X_keys, y_keys, cache=cache, record_transform=rt, batch_size=cfg.BATCH_SIZE, train_split=cfg.TRAIN_TEST_SPLIT)
     train_gens, val_gens = tub_chain.train_val_gen()
 
     model_path = os.path.expanduser(model_name)
@@ -240,7 +240,8 @@ if __name__ == '__main__':
     elif args['train']:
         tub = args['--tub']
         model = args['--model']
-        train(cfg, tub, model)
+        cache = args['--cache']
+        train(cfg, tub, model, cache)
 
     elif args['check']:
         tub = args['--tub']

--- a/donkeycar/templates/donkey2.py
+++ b/donkeycar/templates/donkey2.py
@@ -148,12 +148,9 @@ def gather_tubs(cfg, tub_names):
     
     if tub_names:
         tub_paths = [os.path.expanduser(n) for n in tub_names.split(',')]
-        tub_paths = expand_path_masks(tub_paths)
+        return expand_path_masks(tub_paths)
     else:
-        tub_paths = [os.path.join(cfg.DATA_PATH, n) for n in os.listdir(cfg.DATA_PATH)]
-
-    tubs = [dk.parts.Tub(p) for p in tub_paths]
-    return tubs
+        return [os.path.join(cfg.DATA_PATH, n) for n in os.listdir(cfg.DATA_PATH)]
 
 
 def train(cfg, tub_names, model_name):
@@ -170,21 +167,14 @@ def train(cfg, tub_names, model_name):
 
     kl = dk.parts.KerasCategorical()
     
-    tubs = gather_tubs(cfg, tub_names)
+    tub_paths = gather_tubs(cfg, tub_names)
 
-    import itertools
-
-    gens = [tub.train_val_gen(X_keys, y_keys, record_transform=rt, batch_size=cfg.BATCH_SIZE, train_split=cfg.TRAIN_TEST_SPLIT) for tub in tubs]
-
-
-    # Training data generator is the one that keeps cycling through training data generator of all tubs chained together
-    # The same for validation generator
-    train_gens = itertools.cycle(itertools.chain(*[gen[0] for gen in gens]))
-    val_gens = itertools.cycle(itertools.chain(*[gen[1] for gen in gens]))
+    tub_chain = dk.parts.TubChain(tub_paths, X_keys, y_keys, record_transform=rt, batch_size=cfg.BATCH_SIZE, train_split=cfg.TRAIN_TEST_SPLIT)
+    train_gens, val_gens = tub_chain.train_val_gen()
 
     model_path = os.path.expanduser(model_name)
 
-    total_records = sum([t.get_num_records() for t in tubs])
+    total_records = tub_chain.total_records()
     total_train = int(total_records * cfg.TRAIN_TEST_SPLIT)
     total_val = total_records - total_train
     print('train: %d, validation: %d' %(total_train, total_val))


### PR DESCRIPTION
Currently the dataset returned from generators will be cached by `itertools.cycle` after 1st epoch. This becomes a problem when I want to use data augmentation to generate unlimited amount of data.

This PR fixes the issue stated above.