### PR TITLE
Extra steps for Mac installation of simulator

### DIFF
--- a/docs/guide/simulator.md
+++ b/docs/guide/simulator.md
@@ -12,6 +12,11 @@ You will need a specific build per platform:
 
 Extract this compressed file. It will create a folder with executable. Double click that executable to launch the simulator.
 
+
+#### Extra Mac Steps
+
+If logs are not being generated you are probably running a version of OS X that sandboxes untrusted applications. This prevents the simulator writing to disk. To resolve this move the executable within the Applications folder.
+
 ### Recorded Data
 
 This simulator can create log data in the donkey tub format. This is stored in the `log` dir at the root of the folder next to the executable. On the mac you will need to browse the package contents to see this folder. If this folder is missing, no data will be recorded.


### PR DESCRIPTION
I had some issues generating logs when running the simulator locally. I checked

/Users/<username>/Library/Logs/Unity/Player.log

and found the following

`
UnauthorizedAccessException: Access to the path "/private/var/folders/.../d/donkey_sim.app/log/log_car_controls.txt" is denied.
`

This is caused by Sierra's sandboxing of untrusted applications, and will probably be an issue for all Mac users.