### PR TITLE
Flipped height and width in ImgStack class.

### DIFF
--- a/donkeycar/parts/cv.py
+++ b/donkeycar/parts/cv.py
@@ -14,42 +14,42 @@ class ImgCanny():
     def __init__(self, low_threshold=60, high_threshold=110):
         self.low_threshold = low_threshold
         self.high_threshold = high_threshold
-        
-        
+
+
     def run(self, img_arr):
-        return cv2.Canny(img_arr, 
-                         self.low_threshold, 
+        return cv2.Canny(img_arr,
+                         self.low_threshold,
                          self.high_threshold)
 
-    
+
 
 class ImgGaussianBlur():
 
     def __init__(self, kernal_size=5):
         self.kernal_size = kernal_size
-        
+
     def run(self, img_arr):
-        return cv2.GaussianBlur(img_arr, 
+        return cv2.GaussianBlur(img_arr,
                                 (self.kernel_size, self.kernel_size), 0)
 
 
 
 class ImgCrop:
     """
-    Crop an image to an area of interest. 
+    Crop an image to an area of interest.
     """
     def __init__(self, top=0, bottom=0, left=0, right=0):
         self.top = top
         self.bottom = bottom
         self.left = left
         self.right = right
-        
+
     def run(self, img_arr):
-        width, height, _ = img_arr.shape
-        img_arr = img_arr[self.top:height-self.bottom, 
+        height, width, _ = img_arr.shape # has already been changed to this on master branch
+        img_arr = img_arr[self.top:height-self.bottom,
                           self.left: width-self.right]
         return img_arr
-        
+
 
 
 class ImgStack:
@@ -66,33 +66,32 @@ class ImgStack:
         take a numpy rgb image return a new single channel image converted to greyscale
         '''
         return np.dot(rgb[...,:3], [0.299, 0.587, 0.114])
-        
+
     def run(self, img_arr):
-        width, height, _ = img_arr.shape        
+        height, width, _ = img_arr.shape
         gray = self.rgb2gray(img_arr)
-        
+
         if self.img_arr is None:
-            self.img_arr = np.zeros([width, height, self.num_channels], dtype=np.dtype('B'))
+            self.img_arr = np.zeros([height, width, self.num_channels], dtype=np.dtype('B'))
 
         for ch in range(self.num_channels - 1):
             self.img_arr[...,ch] = self.img_arr[...,ch+1]
 
-        self.img_arr[...,self.num_channels - 1:] = np.reshape(gray, (width, height, 1))
+        self.img_arr[...,self.num_channels - 1:] = np.reshape(gray, (height, width, 1))
 
         return self.img_arr
 
-        
-        
+
+
 class Pipeline():
     def __init__(self, steps):
         self.steps = steps
-    
+
     def run(self, val):
         for step in self.steps:
             f = step['f']
             args = step['args']
             kwargs = step['kwargs']
-            
+
             val = f(val, *args, **kwargs)
         return val
-    


### PR DESCRIPTION
Simply flipped the height and weight array values to represent what is usually referred to as height and width of arrays or images. The method `run` in the class `ImgStack` worked just fine in spite of this bug because height and weight were interchanged throughout the method.