### PR TITLE
Add 'xcode-select --install' to ## install on Mac

### DIFF
--- a/docs/guide/install_software.md
+++ b/docs/guide/install_software.md
@@ -224,6 +224,12 @@ donkey createcar --path ~/d2
 
 * Start Terminal
 
+* If Xcode or gcc not installed - run the following command to install Command Line Tools for Xcode.
+
+```
+xcode-select --install
+```
+
 * Change to a dir you would like to use as the head of your projects.
 
 ```


### PR DESCRIPTION
Added lines 227 to 231 to remind folk to install gcc / Apple's Command Line for Tools for Xcode if user hasn't either installed.