### PR TITLE
Improved throttle

### DIFF
--- a/donkeycar/parts/camera.py
+++ b/donkeycar/parts/camera.py
@@ -115,11 +115,11 @@ class MockCamera(BaseCamera):
     '''
     Fake camera. Returns only a single static frame
     '''
-    def __init__(self, resolution=(160, 120), image=None):
+    def __init__(self, resolution=(120, 160), image=None):
         if image is not None:
             self.frame = image
         else:
-            self.frame = Image.new('RGB', resolution)
+            self.frame = np.array(Image.new('RGB', (resolution[1], resolution[0])))
 
     def update(self):
         pass

--- a/donkeycar/parts/keras.py
+++ b/donkeycar/parts/keras.py
@@ -90,7 +90,7 @@ class KerasCategorical(KerasPilot):
             throttle = throttle[0][0]
 
         angle_unbinned = dk.utils.linear_unbin(angle_binned)
-        return angle_unbinned, throttle[0][0]
+        return angle_unbinned, throttle
     
     
     

--- a/donkeycar/parts/keras.py
+++ b/donkeycar/parts/keras.py
@@ -79,8 +79,16 @@ class KerasCategorical(KerasPilot):
     def run(self, img_arr):
         img_arr = img_arr.reshape((1,) + img_arr.shape)
         angle_binned, throttle = self.model.predict(img_arr)
-        #print('throttle', throttle)
-        #angle_certainty = max(angle_binned[0])
+        #in order to support older models with continuous throttle,
+        #we will test for shape of throttle to see if it's the newer
+        #binned version.
+        N = len(throttle[0])
+        
+        if N > 0:
+            throttle = dk.utils.linear_unbin(throttle, N=N, offset=0.0, R=0.5)
+        else:
+            throttle = throttle[0][0]
+
         angle_unbinned = dk.utils.linear_unbin(angle_binned)
         return angle_unbinned, throttle[0][0]
     
@@ -150,15 +158,21 @@ def default_categorical():
     from keras.models import Model
     from keras.layers import Convolution2D, MaxPooling2D, Reshape, BatchNormalization
     from keras.layers import Activation, Dropout, Flatten, Dense
-    
+    drop = 0.1
+
     img_in = Input(shape=(120, 160, 3), name='img_in')                      # First layer, input layer, Shape comes from camera.py resolution, RGB
     x = img_in
     x = Convolution2D(24, (5,5), strides=(2,2), activation='relu')(x)       # 24 features, 5 pixel x 5 pixel kernel (convolution, feauture) window, 2wx2h stride, relu activation
+    x = Dropout(drop)(x)                                                    # Randomly drop out (turn off) 10% of the neurons (Prevent overfitting)
     x = Convolution2D(32, (5,5), strides=(2,2), activation='relu')(x)       # 32 features, 5px5p kernel window, 2wx2h stride, relu activatiion
+    x = Dropout(drop)(x)                                                    # Randomly drop out (turn off) 10% of the neurons (Prevent overfitting)
     x = Convolution2D(64, (5,5), strides=(2,2), activation='relu')(x)       # 64 features, 5px5p kernal window, 2wx2h stride, relu
+    x = Dropout(drop)(x)                                                    # Randomly drop out (turn off) 10% of the neurons (Prevent overfitting)
     x = Convolution2D(64, (3,3), strides=(2,2), activation='relu')(x)       # 64 features, 3px3p kernal window, 2wx2h stride, relu
+    x = Dropout(drop)(x)                                                    # Randomly drop out (turn off) 10% of the neurons (Prevent overfitting)
     x = Convolution2D(64, (3,3), strides=(1,1), activation='relu')(x)       # 64 features, 3px3p kernal window, 1wx1h stride, relu
-
+    x = Dropout(drop)(x)                                                    # Randomly drop out (turn off) 10% of the neurons (Prevent overfitting)
+    
     # Possibly add MaxPooling (will make it less sensitive to position in image).  Camera angle fixed, so may not to be needed
 
     x = Flatten(name='flattened')(x)                                        # Flatten to 1D (Fully connected)
@@ -169,14 +183,14 @@ def default_categorical():
     #categorical output of the angle
     angle_out = Dense(15, activation='softmax', name='angle_out')(x)        # Connect every input with every output and output 15 hidden units. Use Softmax to give percentage. 15 categories and find best one based off percentage 0.0-1.0
     
-    #continous output of throttle
-    throttle_out = Dense(1, activation='relu', name='throttle_out')(x)      # Reduce to 1 number, Positive number only
+    #categorical output of throttle
+    throttle_out = Dense(20, activation='softmax', name='throttle_out')(x)  # Connect every input with every output and output 20 hidden units. Use Softmax to give percentage. 20 categories and find best one based off percentage 0.0-1.0
     
     model = Model(inputs=[img_in], outputs=[angle_out, throttle_out])
     model.compile(optimizer='adam',
                   loss={'angle_out': 'categorical_crossentropy', 
-                        'throttle_out': 'mean_absolute_error'},
-                  loss_weights={'angle_out': 0.9, 'throttle_out': .001})
+                        'throttle_out': 'categorical_crossentropy'},
+                  loss_weights={'angle_out': 0.5, 'throttle_out': 1.0})
 
     return model
 

--- a/donkeycar/templates/donkey2.py
+++ b/donkeycar/templates/donkey2.py
@@ -139,6 +139,7 @@ def train(cfg, tub_names, model_name):
 
     def rt(record):
         record['user/angle'] = dk.utils.linear_bin(record['user/angle'])
+        record['user/throttle'] = dk.utils.linear_bin(record['user/throttle'], N=20, offset=0, R=0.5)
         return record
 
     kl = KerasCategorical()

--- a/donkeycar/utils.py
+++ b/donkeycar/utils.py
@@ -148,6 +148,13 @@ BINNING
 functions to help converte between floating point numbers and categories.
 '''
 
+def clamp(n, min, max):
+    if n < min:
+        return min
+    if n > max:
+        return max
+    return n
+
 def linear_bin(a, N=15, offset=1, R=2.0):
     '''
     create a bin of length N

--- a/donkeycar/utils.py
+++ b/donkeycar/utils.py
@@ -148,17 +148,28 @@ BINNING
 functions to help converte between floating point numbers and categories.
 '''
 
-def linear_bin(a):
-    a = a + 1
-    b = round(a / (2/14))
-    arr = np.zeros(15)
+def linear_bin(a, N=15, offset=1, R=2.0):
+    '''
+    create a bin of length N
+    map val A to range R
+    offset one hot bin by offset, commonly R/2
+    '''
+    a = a + offset
+    b = round(a / (R/(N-offset)))
+    arr = np.zeros(N)
+    b = clamp(b, 0, N - 1)
     arr[int(b)] = 1
     return arr
 
 
-def linear_unbin(arr):
+def linear_unbin(arr, N=15, offset=-1, R=2.0):
+    '''
+    preform inverse linear_bin, taking
+    one hot encoded arr, and get max value
+    rescale given R range and offset
+    '''
     b = np.argmax(arr)
-    a = b *(2/14) - 1
+    a = b *(R/(N + offset)) + offset
     return a
 
 


### PR DESCRIPTION
These changes have led to improve throttle prediction over the last few months. I feel they would benefit the community.

This changes the default model to use categorical throttle. It will be backwards compatible with older models, but will create new models in the new format going forward. 

I found I needed to add some small dropout to get improved predictions on both angle and throttle. It does converge in slightly more epochs as a result. ( about 2-4 on average ).

I started with the master branch when making these changes. Let me know if you'd prefer to start with the dev branch so fewer problems merging.
