### PR TITLE
Update Mac instructions for installing tensorflow

### DIFF
--- a/docs/guide/install_software.md
+++ b/docs/guide/install_software.md
@@ -259,7 +259,7 @@ source activate donkey
 * Install Tensorflow
 
 ```
-pip install https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.3.0-py3-none-any.whl
+pip install --upgrade https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.8.0-py3-none-any.whl
 ```
 
 


### PR DESCRIPTION
For tenserflow 1.8 that is in donkeycar 2.5.1 you need this new file.
if not you will get error when trying to train model  ModuleNotFoundError: No module named 'tensorflow.python.keras