### PR TITLE
Horizontal flip and shift added for data augmentation

### DIFF
--- a/docs/guide/train_autopilot.md
+++ b/docs/guide/train_autopilot.md
@@ -49,6 +49,31 @@ rsync -r ~/mycar/models/ pi@<your_ip_address>:~/mycar/models/
 python manage.py drive --model ~/mycar/models/mypilot
 ```
 
+## Data Augmentation
+
+You might have noticed that the dataset you first collected is not evenly balanced. You probably have more `0`
+steering than the rest. You might also have more `-1` and `1` since we tend to steer all the way more than we should or only positive steering values if you only drove to the right.
+If the dataset the unbalanced the result of the neural network will be biased towards the most represented values (prior probability distribution).
+
+To correct for that you have a couple function you can use in `donkeycar/parts/augment.py`. To use them, place them in
+the `train_record_transform()` function so that you records get augmented before the neural network sees them.
+
+```py
+from donkeycar.parts.augment import Augmentor
+
+...
+
+augmentor = Augmentor()
+
+def train_record_transform(record):
+	""" convert categorical steering to linear and apply image augmentations """
+	record = augmentor.flip_left_right(record)
+	record = augmentor.random_horizontal_shift(record)
+	return record
+
+...
+```
+
 ## Training Tips:
 
 

--- a/donkeycar/parts/augment.py
+++ b/donkeycar/parts/augment.py
@@ -1,0 +1,49 @@
+import numpy as np
+import random
+
+class Augmentor(object):
+    """
+    This class provides data augmentation functions
+    for enhanced neural network training.
+    """
+    def __init__(self, X_key='cam/image_array',
+                       Y_key='user/angle'):
+        self.X_key = X_key
+        self.Y_key = Y_key
+
+    def flip_left_right(self, record, probability=0.5):
+        """
+        Randomly flips an image in the left right direction
+
+        Args:
+            record: Record containing the image and the angle
+
+        Returns:
+            Flips record with probability self.flip_rate
+        """
+        if random.uniform(0., 1.) < probability:
+            record[self.X_key] = np.fliplr(record[self.X_key])
+            record[self.Y_key] = record[self.Y_key] * -1.
+        return record
+
+    def random_horizontal_shift(self, record, pixel_range=50, pixel_change=0.01):
+        '''
+        Shifts the image horizontally
+
+        Args:
+            record: Recording containing the image and the steering angle
+            pixel_range: By how much the shift can be
+            pixel_change: By how much the steering is affected for each pixel shift
+
+        Return:
+            shifted record
+        '''
+        import cv2
+        dX = pixel_range * np.random.uniform() - pixel_range / 2
+        record[self.Y_key] += dX * pixel_change
+        shift = np.float32([[1,0,dX],[0,1,0]])
+        record[self.X_key] = cv2.warpAffine(record[self.X_key],
+                                            shift,
+                                            (record[self.X_key].shape[1],
+                                             record[self.X_key].shape[0]))
+        return record


### PR DESCRIPTION
In response to #14 

* Horizontal flipping of the image and changes the sign of the steering.

* Horizontal shifting of the image is uniformly distributed over a range of 50 pixels. The effect of the shift onto the steering value is controllable by the `pixel_change` argument.

⚠️ Shifting requires opencv

![shifted](https://user-images.githubusercontent.com/21275829/46906325-abd76a00-cef9-11e8-8dba-3865c42f1654.jpg)

