### PR TITLE
Print message when setting PWM fails.

### DIFF
--- a/donkeycar/parts/actuator.py
+++ b/donkeycar/parts/actuator.py
@@ -21,7 +21,10 @@ class PCA9685:
         self.channel = channel
 
     def set_pulse(self, pulse):
-        self.pwm.set_pwm(self.channel, 0, pulse)
+        try:
+            self.pwm.set_pwm(self.channel, 0, pulse)
+        except OSError as err:
+            print("Unexpected issue setting PWM (check wires to motor board): {0}".format(err))
 
     def run(self, pulse):
         self.set_pulse(pulse)


### PR DESCRIPTION
This prevents the car from completely stopping if there is a weak connection between the host and the peripheral motor board. Otherwise, a single failed set_pwm call will halt the host.

Sorry for not submitting an issue to discuss the solution beforehand; I'm happy to make any desired changes to the solution. This error has ended most of my runs thus far, and I've just now figured out the root cause: weak jumpers to the motor board. This should prevent _halting_ the run for the issue for resiliency's sake. Should something else happen instead?